### PR TITLE
Fix scheduler script termination

### DIFF
--- a/scheduler.js
+++ b/scheduler.js
@@ -10,5 +10,9 @@ glob.sync('./tasks/**/*.js').forEach((file) => {
   const exp = require(path.resolve(file)); // eslint-disable-line global-require
   const task = path.basename(file).replace(/\.js/, '');
   console.log(`Running '${task}' now.`);
-  exp.func(telegram);
+  try {
+    exp.func(telegram);
+  } catch (e) {
+    console.error(e);
+  }
 });

--- a/tasks/weather.js
+++ b/tasks/weather.js
@@ -40,6 +40,8 @@ module.exports = {
 
     if (items.length <= 2) {
       console.log('Not enough items to compare');
+      models.sequelize.close();
+      redisClient.quit();
       return;
     }
 
@@ -48,6 +50,8 @@ module.exports = {
 
     if (latestItem.update_timestamp === await get(KEY_LATEST_UPDATE_TIMESTAMP)) {
       console.log(`Last update timestamp (${latestItem.update_timestamp}) identical, terminating.`)
+      models.sequelize.close();
+      redisClient.quit();
       return;
     }
     set(KEY_LATEST_UPDATE_TIMESTAMP, latestItem.update_timestamp);
@@ -151,5 +155,7 @@ module.exports = {
         console.log(`[${subscriber.id}] Nothing to notify`);
       }
     }
+    models.sequelize.close();
+    redisClient.quit();
   }
 };


### PR DESCRIPTION
# Purpose
This PR fixes the weather task script in order for `scheduler.js` to terminate properly.

I noticed that the scheduler runs were running fine every other run, with one broken run every time (See the 'Cycling' message where the script should have run normally):
![image](https://user-images.githubusercontent.com/7417870/47614085-d66a1b00-dad4-11e8-98f1-944a55cf1ba3.png)

This is one of two fixes I am attempting to solve certain sectors not getting proper 'Cat 1 started' notifications. Often the bot would just notify that Cat 1 was extended for a sector out of nowhere.

Fixes #31. Will re-open the issue in the future if it is not resolved.